### PR TITLE
Hourly_Weather_Station_Example: Print message on serial for HTTP 401

### DIFF
--- a/examples/Inkplate6COLOR/Projects/Inkplate6COLOR_Hourly_Weather_Station/Network.cpp
+++ b/examples/Inkplate6COLOR/Projects/Inkplate6COLOR_Hourly_Weather_Station/Network.cpp
@@ -209,9 +209,10 @@ bool Network::getData(char *city, char *temp1, char *temp2, char *temp3, char *t
     }
     else if (httpCode == 401)
     {
+        Serial.println("Network error (HTTP 401), check API key");
         display.setCursor(50, 290);
         display.setTextSize(3);
-        display.print(F("Network error, probably wrong api key"));
+        display.print(F("Network error (HTTP 401), check API key"));
         display.display();
         while (1)
             ;


### PR DESCRIPTION
As the activation of API keys can take a while it is a common situation to
try this with a not-yet-activated API key, which results in a HTTP 401. While
many other messages are printed to the serial interface, this one is not.
