### PR TITLE
Increase resolution of the dither buffer

### DIFF
--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -110,7 +110,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 
     void getPointsForPosition(const Position &position, const uint16_t imageWidth, const uint16_t imageHeight,
                               const uint16_t screenWidth, const uint16_t screenHeight, uint16_t *posX, uint16_t *posY);
-    uint8_t findClosestPalette(uint32_t c);
+    uint8_t findClosestPalette(uint32_t c, uint16_t bias);
 
   private:
     virtual void startWrite(void) = 0;

--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -130,7 +130,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 #endif
 
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE4) || defined(ARDUINO_INKPLATE7)
-    int32_t ditherBuffer[3][8][E_INK_WIDTH + 20];
+    int16_t ditherBuffer[3][8][E_INK_WIDTH + 20];
 
     const int kernelWidth = _kernelWidth;
     const int kernelHeight = _kernelHeight;
@@ -140,7 +140,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 
     const unsigned char (*kernel)[_kernelWidth] = _kernel;
 #elif ARDUINO_INKPLATE2
-    int32_t ditherBuffer[3][8][E_INK_WIDTH + 20];
+    int16_t ditherBuffer[3][8][E_INK_WIDTH + 20];
 
     const int kernelWidth = _kernelWidth;
     const int kernelHeight = _kernelHeight;

--- a/src/include/Image.h
+++ b/src/include/Image.h
@@ -110,7 +110,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 
     void getPointsForPosition(const Position &position, const uint16_t imageWidth, const uint16_t imageHeight,
                               const uint16_t screenWidth, const uint16_t screenHeight, uint16_t *posX, uint16_t *posY);
-    uint8_t findClosestPalette(uint32_t c, uint16_t bias);
+    uint8_t findClosestPalette(int16_t r, int16_t g, int16_t b);
 
   private:
     virtual void startWrite(void) = 0;
@@ -130,11 +130,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 #endif
 
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE4) || defined(ARDUINO_INKPLATE7)
-    int8_t ditherBuffer[3][16][E_INK_WIDTH + 20];
-
-    int8_t (*ditherBuffer_r)[E_INK_WIDTH + 20] = ditherBuffer[0];
-    int8_t (*ditherBuffer_g)[E_INK_WIDTH + 20] = ditherBuffer[1];
-    int8_t (*ditherBuffer_b)[E_INK_WIDTH + 20] = ditherBuffer[2];
+    int32_t ditherBuffer[3][8][E_INK_WIDTH + 20];
 
     const int kernelWidth = _kernelWidth;
     const int kernelHeight = _kernelHeight;
@@ -144,11 +140,7 @@ class Image : virtual public NetworkClient, virtual public Adafruit_GFX
 
     const unsigned char (*kernel)[_kernelWidth] = _kernel;
 #elif ARDUINO_INKPLATE2
-    int8_t ditherBuffer[3][16][E_INK_HEIGHT + 20];
-
-    int8_t (*ditherBuffer_r)[E_INK_HEIGHT + 20] = ditherBuffer[0];
-    int8_t (*ditherBuffer_g)[E_INK_HEIGHT + 20] = ditherBuffer[1];
-    int8_t (*ditherBuffer_b)[E_INK_HEIGHT + 20] = ditherBuffer[2];
+    int32_t ditherBuffer[3][8][E_INK_WIDTH + 20];
 
     const int kernelWidth = _kernelWidth;
     const int kernelHeight = _kernelHeight;

--- a/src/include/ImageBMP.cpp
+++ b/src/include/ImageBMP.cpp
@@ -112,7 +112,7 @@ void Image::readBmpHeader(uint8_t *buf, bitmapHeader *_h)
 
 #if defined(ARDUINO_INKPLATECOLOR)
             c = c >> 8;
-            palette[i >> 1] |= findClosestPalette(c, 0) << (i & 1 ? 0 : 4);
+            palette[i >> 1] |= findClosestPalette(RED8(c), GREEN8(c), BLUE8(c)) << (i & 1 ? 0 : 4);
             ditherPalette[i] = c;
 #else
             uint8_t r = (c & 0xFF000000) >> 24;
@@ -432,7 +432,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             {
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE2) || defined(ARDUINO_INKPLATE4) ||                      \
     defined(ARDUINO_INKPLATE7)
-                val = findClosestPalette((r << 16) | (g << 8) | (b), 0);
+                val = findClosestPalette(r, g, b);
 #else
                 val = RGB3BIT(r, g, b);
 #endif
@@ -467,7 +467,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             {
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE2) || defined(ARDUINO_INKPLATE4) ||                      \
     defined(ARDUINO_INKPLATE7)
-                val = findClosestPalette((r << 16) | (g << 8) | (b), 0);
+                val = findClosestPalette(r, g, b);
 #else
                 val = RGB3BIT(r, g, b);
 #endif

--- a/src/include/ImageBMP.cpp
+++ b/src/include/ImageBMP.cpp
@@ -112,7 +112,7 @@ void Image::readBmpHeader(uint8_t *buf, bitmapHeader *_h)
 
 #if defined(ARDUINO_INKPLATECOLOR)
             c = c >> 8;
-            palette[i >> 1] |= findClosestPalette(c) << (i & 1 ? 0 : 4);
+            palette[i >> 1] |= findClosestPalette(c, 0) << (i & 1 ? 0 : 4);
             ditherPalette[i] = c;
 #else
             uint8_t r = (c & 0xFF000000) >> 24;
@@ -411,13 +411,6 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
                     val = RGB3BIT(r, g, b);
 #endif
             }
-
-#if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE2) || defined(ARDUINO_INKPLATE4) ||                      \
-    defined(ARDUINO_INKPLATE7)
-            val = findClosestPalette((r << 16) | (g << 8) | (b));
-#else
-            val = RGB3BIT(r, g, b);
-#endif
             writePixel(x + j, (h - y - 1), val);
             break;
         }
@@ -439,7 +432,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             {
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE2) || defined(ARDUINO_INKPLATE4) ||                      \
     defined(ARDUINO_INKPLATE7)
-                val = findClosestPalette((r << 16) | (g << 8) | (b));
+                val = findClosestPalette((r << 16) | (g << 8) | (b), 0);
 #else
                 val = RGB3BIT(r, g, b);
 #endif
@@ -474,7 +467,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             {
 #if defined(ARDUINO_INKPLATECOLOR) || defined(ARDUINO_INKPLATE2) || defined(ARDUINO_INKPLATE4) ||                      \
     defined(ARDUINO_INKPLATE7)
-                val = findClosestPalette((r << 16) | (g << 8) | (b));
+                val = findClosestPalette((r << 16) | (g << 8) | (b), 0);
 #else
                 val = RGB3BIT(r, g, b);
 #endif

--- a/src/include/ImageDitherColor.cpp
+++ b/src/include/ImageDitherColor.cpp
@@ -77,7 +77,12 @@ uint8_t Image::findClosestPalette(int16_t r, int16_t g, int16_t b)
         }
     }
 
-    return contenderList[contenderCount <= 1 ? 0 : rand() % contenderCount];
+    // If your project has a good way to seed rand(),
+    // you can use rand() here to improve dithering quality
+    // when using shades that are exactly between palette colors.
+    //return contenderList[contenderCount <= 1 ? 0 : rand() % contenderCount];
+
+    return contenderList[0];
 }
 
 /**

--- a/src/include/ImageDitherColor.cpp
+++ b/src/include/ImageDitherColor.cpp
@@ -53,21 +53,20 @@ static unsigned int width = E_INK_WIDTH, height = E_INK_HEIGHT;
  * @param       uint32_t c
  *              color of the given pixel
  *
- * @param       uint16_t bias
- *              an arbitrary value used to break ties, should be different
- *              for neighboring pixels, and should ideally be random
- *
  * @return      closest color in pallete array
  */
-uint8_t Image::findClosestPalette(uint32_t c, uint16_t bias)
+uint8_t Image::findClosestPalette(int16_t r, int16_t g, int16_t b)
 {
-    int32_t minDistance = 0x7fffffff;
+    int64_t minDistance = 0x7fffffffffffffff;
     uint8_t contenderCount = 0;
     uint8_t contenderList[sizeof pallete / sizeof pallete[0]];
 
     for (int i = 0; i < sizeof pallete / sizeof pallete[0]; ++i)
     {
-        int32_t currentDistance = COLORDISTSQR(c, pallete[i]);
+        int16_t pr = RED8(pallete[i]);
+        int16_t pg = GREEN8(pallete[i]);
+        int16_t pb = BLUE8(pallete[i]);
+        int64_t currentDistance = SQR(r - pr) + SQR(g - pg) + SQR(b - pb);
         if (currentDistance < minDistance) {
             minDistance = currentDistance;
             contenderList[0] = i;
@@ -78,7 +77,7 @@ uint8_t Image::findClosestPalette(uint32_t c, uint16_t bias)
         }
     }
 
-    return contenderList[bias % contenderCount];
+    return contenderList[contenderCount <= 1 ? 0 : rand() % contenderCount];
 }
 
 /**
@@ -102,19 +101,19 @@ uint8_t Image::ditherGetPixelBmp(uint32_t px, int i, int j, int w, bool paletted
     if (paletted)
         px = ditherPalette[px];
 
-    int16_t r = RED8(px) + ditherBuffer[0][j % 15][i];
-    int16_t g = GREEN8(px) + ditherBuffer[1][j % 15][i];
-    int16_t b = BLUE8(px) + ditherBuffer[2][j % 15][i];
+    int16_t r = RED8(px) + ditherBuffer[0][j % 8][i] / coef;
+    int16_t g = GREEN8(px) + ditherBuffer[1][j % 8][i] / coef;
+    int16_t b = BLUE8(px) + ditherBuffer[2][j % 8][i] / coef;
 
-    ditherBuffer[0][j % 15][i] = 0;
-    ditherBuffer[1][j % 15][i] = 0;
-    ditherBuffer[2][j % 15][i] = 0;
+    // r = max((int16_t)0, min((int16_t)255, r));
+    // g = max((int16_t)0, min((int16_t)255, g));
+    // b = max((int16_t)0, min((int16_t)255, b));
 
-    r = max((int16_t)0, min((int16_t)255, r));
-    g = max((int16_t)0, min((int16_t)255, g));
-    b = max((int16_t)0, min((int16_t)255, b));
+    ditherBuffer[0][j % 8][i] = 0;
+    ditherBuffer[1][j % 8][i] = 0;
+    ditherBuffer[2][j % 8][i] = 0;
 
-    int closest = findClosestPalette(((uint32_t)r << 16) | ((uint32_t)g << 8) | ((uint32_t)b), i + j);
+    int closest = findClosestPalette(r, g, b);
 
     int32_t rErr = r - (int32_t)((pallete[closest] >> 16) & 0xFF);
     int32_t gErr = g - (int32_t)((pallete[closest] >> 8) & 0xFF);
@@ -126,9 +125,9 @@ uint8_t Image::ditherGetPixelBmp(uint32_t px, int i, int j, int w, bool paletted
         {
             if (!(0 <= i + l && i + l < w))
                 continue;
-            ditherBuffer[0][(j + k) % 15][i + l] += (kernel[k][l + kernelX] * rErr) / coef;
-            ditherBuffer[1][(j + k) % 15][i + l] += (kernel[k][l + kernelX] * gErr) / coef;
-            ditherBuffer[2][(j + k) % 15][i + l] += (kernel[k][l + kernelX] * bErr) / coef;
+            ditherBuffer[0][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * rErr);
+            ditherBuffer[1][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * gErr);
+            ditherBuffer[2][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * bErr);
         }
     }
 

--- a/src/include/ImageDitherColor.cpp
+++ b/src/include/ImageDitherColor.cpp
@@ -66,7 +66,7 @@ uint8_t Image::findClosestPalette(int16_t r, int16_t g, int16_t b)
         int16_t pr = RED8(pallete[i]);
         int16_t pg = GREEN8(pallete[i]);
         int16_t pb = BLUE8(pallete[i]);
-        int64_t currentDistance = SQR(r - pr) + SQR(g - pg) + SQR(b - pb);
+        int32_t currentDistance = SQR(r - pr) + SQR(g - pg) + SQR(b - pb);
         if (currentDistance < minDistance) {
             minDistance = currentDistance;
             contenderList[0] = i;
@@ -109,10 +109,6 @@ uint8_t Image::ditherGetPixelBmp(uint32_t px, int i, int j, int w, bool paletted
     int16_t r = RED8(px) + ditherBuffer[0][j % 8][i] / coef;
     int16_t g = GREEN8(px) + ditherBuffer[1][j % 8][i] / coef;
     int16_t b = BLUE8(px) + ditherBuffer[2][j % 8][i] / coef;
-
-    // r = max((int16_t)0, min((int16_t)255, r));
-    // g = max((int16_t)0, min((int16_t)255, g));
-    // b = max((int16_t)0, min((int16_t)255, b));
 
     ditherBuffer[0][j % 8][i] = 0;
     ditherBuffer[1][j % 8][i] = 0;

--- a/src/include/ImageDitherColor.cpp
+++ b/src/include/ImageDitherColor.cpp
@@ -106,13 +106,17 @@ uint8_t Image::ditherGetPixelBmp(uint32_t px, int i, int j, int w, bool paletted
     if (paletted)
         px = ditherPalette[px];
 
-    int16_t r = RED8(px) + ditherBuffer[0][j % 8][i] / coef;
-    int16_t g = GREEN8(px) + ditherBuffer[1][j % 8][i] / coef;
-    int16_t b = BLUE8(px) + ditherBuffer[2][j % 8][i] / coef;
+    int16_t r = RED8(px) + ditherBuffer[0][j % 8][i];
+    int16_t g = GREEN8(px) + ditherBuffer[1][j % 8][i];
+    int16_t b = BLUE8(px) + ditherBuffer[2][j % 8][i];
 
     ditherBuffer[0][j % 8][i] = 0;
     ditherBuffer[1][j % 8][i] = 0;
     ditherBuffer[2][j % 8][i] = 0;
+
+    r = max((int16_t)0, min((int16_t)255, r));
+    g = max((int16_t)0, min((int16_t)255, g));
+    b = max((int16_t)0, min((int16_t)255, b));
 
     int closest = findClosestPalette(r, g, b);
 
@@ -126,9 +130,9 @@ uint8_t Image::ditherGetPixelBmp(uint32_t px, int i, int j, int w, bool paletted
         {
             if (!(0 <= i + l && i + l < w))
                 continue;
-            ditherBuffer[0][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * rErr);
-            ditherBuffer[1][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * gErr);
-            ditherBuffer[2][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * bErr);
+            ditherBuffer[0][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * rErr) / coef;
+            ditherBuffer[1][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * gErr) / coef;
+            ditherBuffer[2][(j + k) % 8][i + l] += (kernel[k][l + kernelX] * bErr) / coef;
         }
     }
 

--- a/src/include/ImageDitherColorKernels.h
+++ b/src/include/ImageDitherColorKernels.h
@@ -23,12 +23,12 @@
 // one you want below
 
 // Floyd Steinberg
-const int _coef = 16;
-const int _kernelX = 1;
-const unsigned char _kernel[3][4] = {
-    {0, 0, 7},
-    {3, 5, 1},
-};
+// const int _coef = 16;
+// const int _kernelX = 1;
+// const unsigned char _kernel[2][3] = {
+//     {0, 0, 7},
+//     {3, 5, 1},
+// };
 
 /*
 //J F Jarvis, C N Judice, and W H Ninke "Minimized Average Error"
@@ -41,7 +41,7 @@ const unsigned char _kernel[3][5] = {
 };
 */
 
-/*
+
 // Atkinson
 const int _coef = 8;
 const int _kernelX = 1;
@@ -50,7 +50,7 @@ const unsigned char _kernel[3][4] = {
     {1, 1, 1, 0},
     {0, 1, 0, 0},
 };
-*/
+
 
 /*
 // Burkes

--- a/src/include/ImageDitherColorKernels.h
+++ b/src/include/ImageDitherColorKernels.h
@@ -23,12 +23,12 @@
 // one you want below
 
 // Floyd Steinberg
-// const int _coef = 16;
-// const int _kernelX = 1;
-// const unsigned char _kernel[2][3] = {
-//     {0, 0, 7},
-//     {3, 5, 1},
-// };
+const int _coef = 16;
+const int _kernelX = 1;
+const unsigned char _kernel[2][3] = {
+    {0, 0, 7},
+    {3, 5, 1},
+};
 
 /*
 //J F Jarvis, C N Judice, and W H Ninke "Minimized Average Error"
@@ -41,7 +41,7 @@ const unsigned char _kernel[3][5] = {
 };
 */
 
-
+/*
 // Atkinson
 const int _coef = 8;
 const int _kernelX = 1;
@@ -50,6 +50,7 @@ const unsigned char _kernel[3][4] = {
     {1, 1, 1, 0},
     {0, 1, 0, 0},
 };
+*/
 
 
 /*
@@ -88,3 +89,4 @@ const int _kernelWidth = (sizeof _kernel[0] / sizeof _kernel[0][0]);
 const int _kernelHeight = (sizeof _kernel / sizeof _kernel[0]);
 
 #endif
+

--- a/src/include/ImageJPEG.cpp
+++ b/src/include/ImageJPEG.cpp
@@ -390,7 +390,7 @@ bool Image::drawJpegChunk(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t
             }
             else
             {
-                val = _imagePtrJpeg->findClosestPalette(((uint32_t)r << 16) | ((uint32_t)g << 8) | ((uint32_t)b), 0);
+                val = _imagePtrJpeg->findClosestPalette(r, g, b);
             }
 
             _imagePtrJpeg->writePixel(x + i, y + j, val);

--- a/src/include/ImageJPEG.cpp
+++ b/src/include/ImageJPEG.cpp
@@ -390,7 +390,7 @@ bool Image::drawJpegChunk(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t
             }
             else
             {
-                val = _imagePtrJpeg->findClosestPalette(((uint32_t)r << 16) | ((uint32_t)g << 8) | ((uint32_t)b));
+                val = _imagePtrJpeg->findClosestPalette(((uint32_t)r << 16) | ((uint32_t)g << 8) | ((uint32_t)b), 0);
             }
 
             _imagePtrJpeg->writePixel(x + i, y + j, val);

--- a/src/include/ImagePNG.cpp
+++ b/src/include/ImagePNG.cpp
@@ -77,7 +77,7 @@ void pngle_on_draw(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t 
                     b = 255 - b;
                 }
 
-                uint8_t px = _imagePtrPng->findClosestPalette((r << 16) | (g << 8) | (b));
+                uint8_t px = _imagePtrPng->findClosestPalette((r << 16) | (g << 8) | (b), (_pngX + x + i) + (_pngY + y + j));
 #else
                 uint8_t px = RGB3BIT(r, g, b);
 #endif

--- a/src/include/ImagePNG.cpp
+++ b/src/include/ImagePNG.cpp
@@ -77,7 +77,7 @@ void pngle_on_draw(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t 
                     b = 255 - b;
                 }
 
-                uint8_t px = _imagePtrPng->findClosestPalette((r << 16) | (g << 8) | (b), (_pngX + x + i) + (_pngY + y + j));
+                uint8_t px = _imagePtrPng->findClosestPalette(r, g, b);
 #else
                 uint8_t px = RGB3BIT(r, g, b);
 #endif

--- a/src/include/defines.h
+++ b/src/include/defines.h
@@ -199,7 +199,7 @@
 
 #define DATA 0x0E8C0030
 
-#define SQR(a)             ((int32_t)(a) * (int32_t)(a))
+#define SQR(a)             ((int64_t)(a) * (int64_t)(a))
 #define COLORDISTSQR(x, y) (SQR(RED8(x) - RED8(y)) + SQR(GREEN8(x) - GREEN8(y)) + SQR(BLUE8(x) - BLUE8(y)))
 
 #endif

--- a/src/include/defines.h
+++ b/src/include/defines.h
@@ -199,7 +199,7 @@
 
 #define DATA 0x0E8C0030
 
-#define SQR(a)             ((int64_t)(a) * (int64_t)(a))
+#define SQR(a)             ((int32_t)(a) * (int32_t)(a))
 #define COLORDISTSQR(x, y) (SQR(RED8(x) - RED8(y)) + SQR(GREEN8(x) - GREEN8(y)) + SQR(BLUE8(x) - BLUE8(y)))
 
 #endif


### PR DESCRIPTION
- Upgrade `ditherbuffer` from `int8_t` to `int16_t`. This allows the dither buffer to handle error margins the size of entire color channels, such as when cyan is corrected to either green, blue, or white on the Inkplate 6COLOR.
- Modify the `findClosestPalette` function to take the 3 color channels individually, thus allowing them to take the negative values, or >255 values, that occasionally appear with allowing `ditherBuffer` to have this expanded range.
- Modify the `findClosestPalette` function to more easily account for tiebreakers. (The given code is functionally the same as before, but a one-line tweak, suggested in the comments, will allow it to randomly choose from any tiebreaker color on a project that can properly seed `rand()`.)