### PR TITLE
Make the Inkplate6 check the final elif in include/defines.h

### DIFF
--- a/src/include/defines.h
+++ b/src/include/defines.h
@@ -21,9 +21,7 @@
 
 #include "Arduino.h"
 
-#if (defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6V2))
-#include "../boards/Inkplate6.h"
-#elif ARDUINO_INKPLATE5
+#if ARDUINO_INKPLATE5
 #include "../boards/Inkplate5.h"
 #elif (defined(ARDUINO_INKPLATE10) || defined(ARDUINO_INKPLATE10V2))
 #include "../boards/Inkplate10.h"
@@ -39,6 +37,8 @@
 #include "../boards/Inkplate7.h"
 #elif ARDUINO_INKPLATE4TEMPERA
 #include "../boards/Inkplate4TEMPERA.h"
+#elif (defined(ARDUINO_ESP32_DEV) || defined(ARDUINO_INKPLATE6V2))
+#include "../boards/Inkplate6.h"
 #endif
 
 #define INKPLATE6_WAVEFORM1     0


### PR DESCRIPTION
This prevents `-DARDUINO_ESP32_DEV` from clobbering the checks for other boards. This is especially a problem when building with PlatformIO and using the esp32dev board definition, which sets `-DARDUINO_ESP32_DEV`, necessitating the use of `build_unflags` in platformio.ini.

This bug causes issues for me when building for my Inkplate 6plus with PlatformIO. The following platformio.ini causes the build to fail.

```
[env:inkplate6plus]
platform = espressif32
board = esp32dev
board_build.f_cpu = 240000000L
framework = espidf, arduino
monitor_speed = 115200
build_flags =
  -DARDUINO_INKPLATE6PLUS
  -DBOARD_HAS_PSRAM
  -mfix-esp32-psram-cache-issue
build_unflags =
  -Werror=all
lib_deps =
  https://github.com/SolderedElectronics/Inkplate-Arduino-library
```
To get it to work, I need to add `-DARDUINO_ESP32_DEV` to `build_unflags`. Since I'm not sure if that will have other unintended consequences, it seemed safer to fix the order of the checks in the Inkplate library itself.

